### PR TITLE
upgrading

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -71,24 +71,24 @@
         <timestamp>${maven.build.timestamp}</timestamp>
         <maven.build.timestamp.format>yyyyMMddHHmm</maven.build.timestamp.format>
 
-        <scala.version>2.11.12</scala.version>
-        <scala.compat.version>2.11</scala.compat.version>
-        <scalatest.version>3.0.5</scalatest.version>
+        <scala.version>2.13.6</scala.version>
+        <scala.compat.version>2.13</scala.compat.version>
+        <scalatest.version>3.2.10</scalatest.version>
 
         <ubirch-config.version>0.2.5-SNAPSHOT</ubirch-config.version>
         <ubirch-deep-check.version>0.4.2-SNAPSHOT</ubirch-deep-check.version>
         <ubirch-json.version>0.5.3-SNAPSHOT</ubirch-json.version>
         <ubirch-uuid.version>0.1.5-SNAPSHOT</ubirch-uuid.version>
         <elasticsearch.version>7.15.0</elasticsearch.version>
-        <testcontainers-elasticsearch.version>0.39.11</testcontainers-elasticsearch.version>
-        <testcontainers.version>0.39.11</testcontainers.version>
-        <monix.version>3.2.2</monix.version>
-        <json4s.version>3.6.0</json4s.version>
-        <scala-logging.version>3.9.0</scala-logging.version>
-        <slf4j.version>1.7.25</slf4j.version>
-        <logback.version>1.2.3</logback.version>
-        <logstash-logback.version>5.2</logstash-logback.version>
-        <log4j-to-slf4j.version>2.8.2</log4j-to-slf4j.version>
+        <testcontainers-elasticsearch.version>0.39.12</testcontainers-elasticsearch.version>
+        <testcontainers.version>0.39.12</testcontainers.version>
+        <monix.version>3.4.0</monix.version>
+        <json4s.version>4.0.3</json4s.version>
+        <scala-logging.version>3.9.4</scala-logging.version>
+        <slf4j.version>1.7.32</slf4j.version>
+        <logback.version>1.2.10</logback.version>
+        <logstash-logback.version>7.0.1</logstash-logback.version>
+        <log4j-to-slf4j.version>2.17.1</log4j-to-slf4j.version>
 
         <!-- plugins -->
         <maven-deploy-plugin.version>2.8.2</maven-deploy-plugin.version>

--- a/pom.xml
+++ b/pom.xml
@@ -22,7 +22,7 @@
 
     <groupId>com.ubirch.util</groupId>
     <artifactId>ubirch-elasticsearch-utils_${scala.compat.version}</artifactId>
-    <version>0.2.9-SNAPSHOT</version>
+    <version>0.2.9</version>
     <packaging>jar</packaging>
 
     <licenses>
@@ -75,10 +75,10 @@
         <scala.compat.version>2.13</scala.compat.version>
         <scalatest.version>3.2.10</scalatest.version>
 
-        <ubirch-config.version>0.2.5-SNAPSHOT</ubirch-config.version>
-        <ubirch-deep-check.version>0.4.2-SNAPSHOT</ubirch-deep-check.version>
-        <ubirch-json.version>0.5.3-SNAPSHOT</ubirch-json.version>
-        <ubirch-uuid.version>0.1.5-SNAPSHOT</ubirch-uuid.version>
+        <ubirch-config.version>0.2.5</ubirch-config.version>
+        <ubirch-deep-check.version>0.4.2</ubirch-deep-check.version>
+        <ubirch-json.version>0.5.3</ubirch-json.version>
+        <ubirch-uuid.version>0.1.5</ubirch-uuid.version>
         <elasticsearch.version>7.15.0</elasticsearch.version>
         <testcontainers-elasticsearch.version>0.39.12</testcontainers-elasticsearch.version>
         <testcontainers.version>0.39.12</testcontainers.version>

--- a/src/test/scala/com/ubirch/util/elasticsearch/EsBulkClientSpec.scala
+++ b/src/test/scala/com/ubirch/util/elasticsearch/EsBulkClientSpec.scala
@@ -8,9 +8,9 @@ class EsBulkClientSpec extends TestUtils {
 
   val listOfDocs: Seq[TestDoc] = Range(1, 1999).map { int => TestDoc(int.toString, "World", 1 * int) }
 
-  feature("simple CRUD tests") {
+  Feature("simple CRUD tests") {
 
-    scenario("store 2000 documents and check if average is good") {
+    Scenario("store 2000 documents and check if average is good") {
       esMappingImpl.cleanElasticsearch()
       listOfDocs.foreach { testDoc =>
         val jval = Json4sUtil.any2jvalue(testDoc).get

--- a/src/test/scala/com/ubirch/util/elasticsearch/EsMappingSpec.scala
+++ b/src/test/scala/com/ubirch/util/elasticsearch/EsMappingSpec.scala
@@ -5,9 +5,9 @@ import org.elasticsearch.client.indices.GetIndexRequest
 
 class EsMappingSpec extends TestUtils {
 
-  feature("create index with mapping") {
+  Feature("create index with mapping") {
 
-    scenario("testIndex") {
+    Scenario("testIndex") {
       esMappingImpl.createElasticsearchMappings()
       val request = new GetIndexRequest(docIndex)
       assert(client.indices().exists(request, RequestOptions.DEFAULT), true)
@@ -15,4 +15,3 @@ class EsMappingSpec extends TestUtils {
   }
 
 }
-

--- a/src/test/scala/com/ubirch/util/elasticsearch/EsRetrySpec.scala
+++ b/src/test/scala/com/ubirch/util/elasticsearch/EsRetrySpec.scala
@@ -45,9 +45,9 @@ class EsRetrySpec extends TestUtils {
     }
   }
 
-  feature("simple retry") {
+  Feature("simple retry") {
 
-    scenario("fail with no retry") {
+    Scenario("fail with no retry") {
       val mockClient = new MockIOExceptionEsSimpleClient(0, client)
       recoverToExceptionIf[IOException] {
         mockClient.storeDoc(docIndex = docIndex, docIdOpt = Some(testDoc.id), doc = jValue)
@@ -57,7 +57,7 @@ class EsRetrySpec extends TestUtils {
       }
     }
 
-    scenario("fail with two retries") {
+    Scenario("fail with two retries") {
       val mockClient = new MockIOExceptionEsSimpleClient(2, client)
       recoverToExceptionIf[IOException] {
         mockClient.storeDoc(docIndex = docIndex, docIdOpt = Some(testDoc.id), doc = jValue)
@@ -68,9 +68,9 @@ class EsRetrySpec extends TestUtils {
     }
   }
 
-  feature("simple failure when unknown exception") {
+  Feature("simple failure when unknown exception") {
 
-    scenario("fail with no retry") {
+    Scenario("fail with no retry") {
       val mockClient = new MockThrowableEsSimpleClient(0, client)
       recoverToExceptionIf[Throwable] {
         mockClient.storeDoc(docIndex = docIndex, docIdOpt = Some(testDoc.id), doc = jValue)
@@ -80,7 +80,7 @@ class EsRetrySpec extends TestUtils {
       }
     }
 
-    scenario("fail with no retry also though maxRetries > 0") {
+    Scenario("fail with no retry also though maxRetries > 0") {
       val mockClient = new MockThrowableEsSimpleClient(2, client)
       recoverToExceptionIf[Throwable] {
         mockClient.storeDoc(docIndex = docIndex, docIdOpt = Some(testDoc.id), doc = jValue)
@@ -91,9 +91,9 @@ class EsRetrySpec extends TestUtils {
     }
   }
 
-  feature("fail all remaining methods with one retry") {
+  Feature("fail all remaining methods with one retry") {
 
-    scenario("getDoc") {
+    Scenario("getDoc") {
       val mockClient = new MockIOExceptionEsSimpleClient(1, client)
       recoverToExceptionIf[IOException] {
         mockClient.getDoc(docIndex, testDoc.id)
@@ -103,7 +103,7 @@ class EsRetrySpec extends TestUtils {
       }
     }
 
-    scenario("getDocs") {
+    Scenario("getDocs") {
       val mockClient = new MockIOExceptionEsSimpleClient(1, client)
       val query = Some(QueryBuilders.termQuery("id", testDoc.id))
       recoverToExceptionIf[IOException] {
@@ -114,7 +114,7 @@ class EsRetrySpec extends TestUtils {
       }
     }
 
-    scenario("getAverage() of existing field --> Some") {
+    Scenario("getAverage() of existing field --> Some") {
       val mockClient = new MockIOExceptionEsSimpleClient(1, client)
       val aggregation = AggregationBuilders.avg("average").field("value")
       recoverToExceptionIf[IOException] {
@@ -125,7 +125,7 @@ class EsRetrySpec extends TestUtils {
       }
     }
 
-    scenario("delete") {
+    Scenario("delete") {
       val mockClient = new MockIOExceptionEsSimpleClient(1, client)
       recoverToExceptionIf[IOException] {
         mockClient.deleteDoc(docIndex, testDoc.id)
@@ -135,7 +135,7 @@ class EsRetrySpec extends TestUtils {
       }
     }
 
-    scenario("connectivityCheck with existing index") {
+    Scenario("connectivityCheck with existing index") {
       val mockClient = new MockIOExceptionEsSimpleClient(1, client)
       mockClient.connectivityCheck(docIndex).map { _ =>
         mockClient.counter shouldBe 2

--- a/src/test/scala/com/ubirch/util/elasticsearch/EsSimpleClientSpec.scala
+++ b/src/test/scala/com/ubirch/util/elasticsearch/EsSimpleClientSpec.scala
@@ -21,9 +21,9 @@ class EsSimpleClientSpec extends TestUtils {
   private val testDoc2 = TestDoc("2", "Galaxy", 20)
   private val testDoc2Updated = TestDoc("2", "Galaxy-World", 10)
 
-  feature("simple CRUD tests") {
+  Feature("simple CRUD tests") {
 
-    scenario("store") {
+    Scenario("store") {
       val jval = Json4sUtil.any2jvalue(testDoc).get
 
       simpleClient
@@ -36,13 +36,13 @@ class EsSimpleClientSpec extends TestUtils {
         }
     }
 
-    scenario("failed get") {
+    Scenario("failed get") {
       simpleClient.getDoc(docIndex, UUIDUtil.uuidStr).map {
         _.isDefined shouldBe false
       }
     }
 
-    scenario("store and get") {
+    Scenario("store and get") {
       val jval = Json4sUtil.any2jvalue(testDoc).get
 
       simpleClient.storeDoc(
@@ -63,7 +63,7 @@ class EsSimpleClientSpec extends TestUtils {
       }
     }
 
-    scenario("update") {
+    Scenario("update") {
       val jval = Json4sUtil.any2jvalue(testDoc2).get
       Await.ready(
         simpleClient.storeDoc(
@@ -101,7 +101,7 @@ class EsSimpleClientSpec extends TestUtils {
       }
     }
 
-    scenario("getDocs with id") {
+    Scenario("getDocs with id") {
       Thread.sleep(1000)
 
       val query = Some(QueryBuilders.termQuery("id", testDoc2Updated.id))
@@ -112,7 +112,7 @@ class EsSimpleClientSpec extends TestUtils {
       }
     }
 
-    scenario("getDocs") {
+    Scenario("getDocs") {
       simpleClient.getDocs(docIndex).map {
         case jvals: List[JValue] =>
           jvals.size shouldBe 2
@@ -120,7 +120,7 @@ class EsSimpleClientSpec extends TestUtils {
       }
     }
 
-    scenario("getAverage() of existing field --> Some") {
+    Scenario("getAverage() of existing field --> Some") {
 
       val aggregation: AvgAggregationBuilder =
         AggregationBuilders
@@ -137,7 +137,7 @@ class EsSimpleClientSpec extends TestUtils {
 
     }
 
-    scenario("getAverage() of non-existing field --> None") {
+    Scenario("getAverage() of non-existing field --> None") {
 
       val aggregation: AvgAggregationBuilder =
         AggregationBuilders
@@ -153,7 +153,7 @@ class EsSimpleClientSpec extends TestUtils {
 
     }
 
-    scenario("delete") {
+    Scenario("delete") {
       val jval = Json4sUtil.any2jvalue(testDoc).get
       simpleClient.storeDoc(
         docIndex = docIndex,

--- a/src/test/scala/com/ubirch/util/elasticsearch/TestUtils.scala
+++ b/src/test/scala/com/ubirch/util/elasticsearch/TestUtils.scala
@@ -5,7 +5,9 @@ import com.typesafe.scalalogging.StrictLogging
 import com.ubirch.util.json.JsonFormats
 import org.elasticsearch.client.RestHighLevelClient
 import org.json4s.Formats
-import org.scalatest.{ AsyncFeatureSpec, BeforeAndAfterAll, Matchers }
+import org.scalatest.BeforeAndAfterAll
+import org.scalatest.featurespec.AsyncFeatureSpec
+import org.scalatest.matchers.should.Matchers
 import org.testcontainers.utility.DockerImageName
 
 case class TestDoc(id: String, hello: String, value: Int)

--- a/src/test/scala/com/ubirch/util/elasticsearch/config/ESConfigSpec.scala
+++ b/src/test/scala/com/ubirch/util/elasticsearch/config/ESConfigSpec.scala
@@ -1,12 +1,13 @@
 package com.ubirch.util.elasticsearch.config
 
-import org.scalatest.{ FeatureSpec, Matchers }
+import org.scalatest.featurespec.AnyFeatureSpec
+import org.scalatest.matchers.should.Matchers
 
-class ESConfigSpec extends FeatureSpec with Matchers {
+class ESConfigSpec extends AnyFeatureSpec with Matchers {
 
-  feature("hosts()") {
+  Feature("hosts()") {
 
-    scenario("read list of hosts from config") {
+    Scenario("read list of hosts from config") {
 
       // verify
       EsHighLevelConfig.host shouldBe "localhost"
@@ -20,9 +21,9 @@ class ESConfigSpec extends FeatureSpec with Matchers {
     }
   }
 
-  feature("bulk()") {
+  Feature("bulk()") {
 
-    scenario("read bulk settings from config") {
+    Scenario("read bulk settings from config") {
 
       // verify
       EsHighLevelConfig.bulkActions shouldBe 10000


### PR DESCRIPTION
- scala to 2.13.6
- scala-test to 3.2.10
- scala-logging 3.9.4
- json4s to 4.0.3
- logback 1.2.10
- logstash-logback-encoder 7.0.1
- log4j-to-slf4j 2.17.1
- slf4j.api 1.7.32